### PR TITLE
Added BoxeeBox lirc socket location to startup of xbmc.

### DIFF
--- a/hack/xbmc.sh
+++ b/hack/xbmc.sh
@@ -10,7 +10,7 @@ do
 			fi
 			cd ${p}
 			chmod +x ${p}/xbmc.bin
-			HOME=${p} GCONV_PATH=${p}/gconv AE_ENGINE=active PYTHONPATH=${p}/python2.7:${p}/python2.7/lib-dynload PYTHONHOME=${p}/python2.7:${p}/python2.7/lib-dynload XBMC_HOME=${p} ${p}/xbmc.bin --standalone -p 2>>/tmp/xbmc.log
+			HOME=${p} GCONV_PATH=${p}/gconv AE_ENGINE=active PYTHONPATH=${p}/python2.7:${p}/python2.7/lib-dynload PYTHONHOME=${p}/python2.7:${p}/python2.7/lib-dynload XBMC_HOME=${p} ${p}/xbmc.bin --standalone -p -l /var/run/lirc/lircd 2>>/tmp/xbmc.log
 			ret=$?
 			break
 		fi


### PR DESCRIPTION
BoxeeBox uses the lirc socket in /var/run/lirc/lircd, but xbmc expects it to be at /dev/lircd.
Because of this BoxeeBox can use the infrared receiver, but XBMC cannot connect to it.
The argument to xbmc.bin tells it to look for /var/run/lirc/lircd instead.
