### PR TITLE
Option to hide the Weather and Clock on the Home Screen

### DIFF
--- a/hack/boxee/skin/boxee/720p/Home.xml
+++ b/hack/boxee/skin/boxee/720p/Home.xml
@@ -100,7 +100,7 @@
 					</control>
 					<!-- WEATHER -->
 					<control type="group">
-						<visible>boxee.HasInternetConnection + Weather.IsFetched</visible>
+						<visible>boxee.HasInternetConnection + Weather.IsFetched + StringCompare(Skin.String(homeenabled-weather),0)</visible>						
 						<width>100</width>
 						<control type="button" id="8888">
 							<onleft>2410</onleft>
@@ -174,6 +174,7 @@
 					</control>
 					<!-- CLOCK -->
 					<control type="grouplist">
+						<visible>StringCompare(Skin.String(homeenabled-clock),0)</visible>
 						<posy>23</posy>
 						<orientation>horizontal</orientation>
 						<itemgap>0</itemgap>

--- a/hack/boxee/skin/boxee/720p/custom_BoxeeHack.xml
+++ b/hack/boxee/skin/boxee/720p/custom_BoxeeHack.xml
@@ -386,6 +386,25 @@
 					<selected>StringCompare(Skin.String(homeenabled-photos),1)</selected>
 					<onclick>XBMC.RunScript("special://skin/720p/scripts/boxeehack_settings.py", "homeenabled", "photos")</onclick>
 				</control>
+				<control type="group" id="113">
+					<height>56</height>
+					<control type="label">
+						<include>SettingsLabel</include>
+						<label>Various</label>
+					</control>
+				</control>
+				<control type="radiobutton" id="114">
+					<include>SettingsRadioButton</include>
+					<label>Hide Weather</label>
+					<selected>StringCompare(Skin.String(homeenabled-weather),1)</selected>
+					<onclick>XBMC.RunScript("special://skin/720p/scripts/boxeehack_settings.py", "homeenabled", "weather")</onclick>
+				</control>
+				<control type="radiobutton" id="115">
+					<include>SettingsRadioButton</include>
+					<label>Hide Clock</label>
+					<selected>StringCompare(Skin.String(homeenabled-clock),1)</selected>
+					<onclick>XBMC.RunScript("special://skin/720p/scripts/boxeehack_settings.py", "homeenabled", "clock")</onclick>
+				</control>				
 			</control>
 			
 			<!-- SUBTITLES -->

--- a/hack/boxee/skin/boxee/720p/scripts/boxeehack_settings.py
+++ b/hack/boxee/skin/boxee/720p/scripts/boxeehack_settings.py
@@ -35,7 +35,7 @@ key = C2FAFCBE34610608
         common.set_string("boxeeplus-version", version_local )
 
 def get_home_enabled_default_list():
-    return "-,friends|Built-in,watchlater,shows|Built-in,movies|Built-in,music|Built-in,apps,files,web,photos"
+    return "-,friends|Built-in,watchlater,shows|Built-in,movies|Built-in,music|Built-in,apps,files,web,photos,weather,clock"
     
 def set_home_enabled_strings():
     homeitems = get_home_enabled_default_list().split(",")


### PR DESCRIPTION
I felt like being able to hide the Weather and Clock on the Home screen
was missing. Especially since showing the weather on your media player
seems a bit unnecessary these days.
