### PR TITLE
Only use dark background when parent view is fanart

### DIFF
--- a/hack/boxee/skin/boxee/720p/boxee_browse_views.xml
+++ b/hack/boxee/skin/boxee/720p/boxee_browse_views.xml
@@ -1579,7 +1579,7 @@
 		<include>Common_Background_Browse_episodes</include>
 
 		<control type="group">
-		        <visible>true</visible><!-- | stringcompare(skin.string(EpisodeViewMode),Overview)</visible> -->
+				<visible>StringCompare(Skin.String(show-thumbnails),3)</visible>
 
 		        <control type="image">
 		                <posx>0</posx>


### PR DESCRIPTION
Fanart is nice. But if you don’t use it the dark background - which is added to the episode view regardless - is not needed. With this change the dark background is only used when the parent view is the Fanart view.
